### PR TITLE
[BUG] CountryVatNumberValidator unexpected notice fix

### DIFF
--- a/src/Constraints/CountryVatNumberValidator.php
+++ b/src/Constraints/CountryVatNumberValidator.php
@@ -36,7 +36,7 @@ class CountryVatNumberValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, VATNumberAwareInterface::class);
         }
 
-        if ($vatNumberArr[0] !== $value->getCountryCode()) {
+        if ($vatNumberArr === null || $vatNumberArr[0] !== $value->getCountryCode()) {
             $this->context->buildViolation($constraint->message)
                 ->setCode($constraint::CORRESPONDENCE_ERROR)
                 ->atPath($constraint->vatNumberPath)


### PR DESCRIPTION
`\Prometee\VIESClient\Util\VatNumberUtil::split` can return null. `\Prometee\SyliusVIESClientPlugin\Constraints\CountryVatNumberValidator` throws notice then: 
`Notice: Trying to access array offset on value of type null`. In my opinion this kind of behavior isn' t correct. I just simply check for null and then build violation in validator, for me it's better way rather than get unexpected notice in this case.