### PR TITLE
[FIX] Setting vatNumber twice using the API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,11 @@ jobs:
                 if: always() && steps.end-of-setup.outcome == 'success'
 
             -
+                name: Container lint
+                run: (cd tests/Application && bin/console lint:container)
+                if: always() && steps.end-of-setup.outcome == 'success'
+
+            -
                 name: Run ECS
                 run: vendor/bin/ecs check src
                 if: always() && steps.end-of-setup.outcome == 'success'

--- a/config/services/mappers.yaml
+++ b/config/services/mappers.yaml
@@ -1,0 +1,6 @@
+services:
+
+    FluxSE\SyliusEUVatPlugin\Mapper\AddressMapper:
+        decorates: sylius.mapper.address
+        arguments:
+            - '.inner'

--- a/config/services/mappers.yaml
+++ b/config/services/mappers.yaml
@@ -1,6 +1,6 @@
 services:
 
     FluxSE\SyliusEUVatPlugin\Mapper\AddressMapper:
-        decorates: sylius.mapper.address
+        decorates: sylius_api.mapper.address
         arguments:
             - '.inner'

--- a/config/services/mappers.yaml
+++ b/config/services/mappers.yaml
@@ -3,4 +3,4 @@ services:
     FluxSE\SyliusEUVatPlugin\Mapper\AddressMapper:
         decorates: sylius_api.mapper.address
         arguments:
-            - '.inner'
+            - '@.inner'

--- a/features/checkout/seeing_order_summary/seeing_total_tax_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_total_tax_on_order_summary_page.feature
@@ -30,6 +30,19 @@ Feature: Seeing tax total on order summary page
     And my tax total should be "$0.00"
 
   @api @ui @javascript
+  Scenario: Seeing the tax total of 20% when VAT number is blank the second time
+    Given I have product "The Sorting Hat" in the cart
+    When I specify the billing address as "Paris", "1 avenue Notre Dame", "75001", "France" for "Dupont Jean"
+    And I specify the billing vat number as "FR10632012100"
+    And I complete the addressing step
+    When I specify the billing address as "Paris2", "1 avenue Notre Dame", "75002", "France" for "Dupont Jean2"
+    And I do not specify the billing vat number
+    And I complete the addressing step
+    And I proceed with "Free" shipping method and "Offline" payment
+    Then I should be on the checkout summary step
+    And my tax total should be "$20.00"
+
+  @api @ui @javascript
   Scenario: Seeing the tax total of 20% when VAT number country is the same as the channel base country on order summary page
     Given I have product "The Sorting Hat" in the cart
     And this channel is based in the "France" country and allow VAT numbers for the "EU" zone

--- a/src/Mapper/AddressMapper.php
+++ b/src/Mapper/AddressMapper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusEUVatPlugin\Mapper;
+
+use FluxSE\SyliusEUVatPlugin\Entity\VATNumberAwareInterface;
+use Sylius\Bundle\ApiBundle\Mapper\AddressMapperInterface;
+use Sylius\Component\Core\Model\AddressInterface;
+use Webmozart\Assert\Assert;
+
+final class AddressMapper implements AddressMapperInterface
+{
+    public function __construct(
+        private readonly AddressMapperInterface $decoratedAddressMapper,
+    ) {
+    }
+
+    public function mapExisting(AddressInterface $currentAddress, AddressInterface $targetAddress): AddressInterface
+    {
+        $address = $this->decoratedAddressMapper->mapExisting($currentAddress, $targetAddress);
+        Assert::isInstanceOf($address, VATNumberAwareInterface::class);
+        Assert::isInstanceOf($targetAddress, VATNumberAwareInterface::class);
+        $address->setVatNumber($targetAddress->getVatNumber());
+
+        return $address;
+    }
+}

--- a/tests/Behat/Context/Api/Shop/Checkout/CheckoutAddressingContext.php
+++ b/tests/Behat/Context/Api/Shop/Checkout/CheckoutAddressingContext.php
@@ -135,8 +135,9 @@ final class CheckoutAddressingContext implements Context
     /**
      * @When /^I specify the (shipping|billing) vat number as "([^"]+)"$/
      * @When /^I try to specify the (shipping|billing) vat number as "([^"]+)"$/
+     * @When /^I do not specify the (shipping|billing) vat number$/
      */
-    public function iSpecifyTheVatNumberAs(string $type, string $vatNumber): void
+    public function iSpecifyTheVatNumberAs(string $type, string $vatNumber = ""): void
     {
         $this->content[$type . 'Address']['vatNumber'] = $vatNumber;
     }

--- a/tests/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/tests/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -18,8 +18,9 @@ final class CheckoutAddressingContext implements Context
     /**
      * @When /^I specify the shipping vat number as "([^"]+)"$/
      * @When /^I try to specify the shipping vat number as "([^"]+)"$/
+     * @When /^I do not specify the shipping vat number$/
      */
-    public function iSpecifyTheShippingVatNumberAs(string $vatNumber): void
+    public function iSpecifyTheShippingVatNumberAs(string $vatNumber = ""): void
     {
         $this->addressPage->specifyShippingVatNumber($vatNumber);
     }
@@ -27,8 +28,9 @@ final class CheckoutAddressingContext implements Context
     /**
      * @When /^I specify the billing vat number as "([^"]+)"$/
      * @When /^I try to specify the billing vat number as "([^"]+)"$/
+     * @When /^I do not specify the billing vat number$/
      */
-    public function iSpecifyTheBillingVatNumberAs(string $vatNumber): void
+    public function iSpecifyTheBillingVatNumberAs(string $vatNumber = ""): void
     {
         $this->addressPage->specifyBillingVatNumber($vatNumber);
     }


### PR DESCRIPTION
When you want to set the VAT number twice during an API call, Sylius introduce a new mapper which was not decorated to handle the `vatNumber` field.

This PR aim to fix this issue.